### PR TITLE
Refactor: Remove unnecessary .format() on fixed format string '>H'

### DIFF
--- a/pynus/backend.py
+++ b/pynus/backend.py
@@ -211,7 +211,7 @@ class BinaryBackendArray(xr.backends.BackendArray):
             # currently only unpacking 2UPC
             base = unpack(">f", f.read(4))[0]
             ampl = unpack(">f", f.read(4))[0]
-            pack = np.array([i[0] for i in iter_unpack(">H".format(nx * ny), f.read(nx * ny * 2))]).reshape(ny, nx)
+            pack = np.array([i[0] for i in iter_unpack(">H", f.read(nx * ny * 2))]).reshape(ny, nx)
             values = base + ampl * pack
         else:
             # TODO: implement other packing methods

--- a/pynus/decode.py
+++ b/pynus/decode.py
@@ -123,7 +123,7 @@ def decode_nusdas(fname, *, variables=None):
                 
                 base = unpack(">f", f.read(4))[0]
                 ampl = unpack(">f", f.read(4))[0]
-                pack = np.array([i[0] for i in iter_unpack(">H".format(nx * ny), f.read(nx * ny * 2))]).reshape(ny, nx)
+                pack = np.array([i[0] for i in iter_unpack(">H", f.read(nx * ny * 2))]).reshape(ny, nx)
                 values = base + ampl * pack
 
                 if c_level == "SURF  ":


### PR DESCRIPTION
### 📄 PR Description
---
This pull request simplifies lines in both `decode.py` and `backend.py` by removing the redundant use of `.format(nx * ny)` on the static `string ">H"`.
Since `">H"` contains no formatting placeholders, the use of `.format()` has no effect and can be safely removed for better readability and performance.

**Updated lines:**

  - `decode.py `, line 126
  - `backend.py`, line 214
----
✅ All existing behavior remains unchanged.
📦 No additional dependencies added or removed.